### PR TITLE
ルーティング方式をNGINX風に更新し、それによって壊れたテストを全て修正しました

### DIFF
--- a/conf_files/test.conf
+++ b/conf_files/test.conf
@@ -1,7 +1,7 @@
 
 server {
-		listen 			8080;
-        server_name  localhost;
+		listen 		8080;
+        server_name  n;
 		root		 /content;
  
         # Load configuration files for the default server block.
@@ -35,4 +35,21 @@ server {
 		index index.php index.test;
 		allowedMethods	GET POST;
 }
+
+server {
+		server_name	komatsud;
+		root		/www/content;
+		rewrite		/content/ok.html yahoo.co.jp;
+		return		202 https://www.google.co.jp/;
+
+		autoindex on;
+		client_max_body_size 10k;
+		upload_path Users/komatsud/webserv/html/www/content/;
+
+		error_page 400 /error_pages/400.html;
+		error_page 501 /error_pages/501.html;
+		index index.php index.test;
+		allowedMethods	GET POST;
+}
+
 

--- a/src/RequestHandler.cpp
+++ b/src/RequestHandler.cpp
@@ -3,15 +3,16 @@
 /*                                                        :::      ::::::::   */
 /*   RequestHandler.cpp                                 :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: shtanemu <shtanemu@student.42.fr>          +#+  +:+       +#+        */
+/*   By: komatsud <komatsud@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/20 17:32:21 by komatsud          #+#    #+#             */
-/*   Updated: 2023/10/25 13:14:14 by shtanemu         ###   ########.fr       */
+/*   Updated: 2023/10/26 16:50:32 by komatsud         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "RequestHandler.hpp"
 
+#include "Address.hpp"
 #include "AMethod.hpp"
 #include "MethodDelete.hpp"
 #include "MethodGet.hpp"
@@ -35,12 +36,14 @@ Result<int, bool> RequestHandler::searchMatchHost() {
 
 	//レスポンスに最低限をセットする
 	res.setVersion("HTTP/1.1");
+	// ( -`ω-)✧
+	res.addHeader("Server", "webserv - shtanemu, komatsud");
 
-	// Hostヘッダー自体が含まれていない場合(どうにもならない)
+	// Hostヘッダーが含まれていない場合は400を返して良い。
 	if (result_1.isOK() == false) {
-#if defined(_DEBUGFLAG)
-		std::cout << RED << "no Host Header is detected" << RESET << std::endl;
-#endif
+		#if defined(_DEBUGFLAG)
+				std::cout << RED << "no Host Header is detected" << RESET << std::endl;
+		#endif
 		res.setStatus(400);
 		res.setStatusMessage("Bad Request");
 		res.addHeader("Content-Length", "0");
@@ -49,52 +52,63 @@ Result<int, bool> RequestHandler::searchMatchHost() {
 
 	hostname = result_1.getOk();
 
-	// std::cout << YELLOW << "hostname: " << hostname << RESET << std::endl;
-
 	// Requestで指定されているhostnameの中にPortの指定が存在するかどうかを確認する
-	if (hostname.find(':') != std::string::npos) {
+	if (hostname.find(':') != std::string::npos)
+	{
 		std::stringstream ss;
+		std::stringstream sb;
+		std::string	tmp;
 
 		portflag = true;
 		ss << hostname;
 		std::getline(ss, without_port, ':');
-		// std::cout << "hostname: " << hostname << std::endl;
-		// std::cout << "without_port: " << without_port << std::endl;
-		ss >> portnum;
-		// std::cout << portnum << std::endl;
-	} else {
+		std::getline(ss, tmp, ':');
+
+		//std::cout << RED"tmp: " << tmp << RESET << std::endl;
+		
+		sb << tmp;
+		sb >> portnum;
+	}
+	else
+	{
 		portflag = false;
+		without_port = hostname;
 	}
 
-	// Configの中からHostが一致するものを探す
-	for (size_t i = 0; i < configs.size(); i++) {
-		// std::cout << YELLOW << "conf siz: " << configs.size() << RESET <<
-		// std::endl;
-		for (size_t t = 0; t < configs.at(i).getServerName().size(); t++) {
-			// Configの時
-			if (portflag == false &&
-				configs.at(i).getServerName().at(t) == hostname) {
-				this->confnum = i;
-				this->addressnum =
-					0;	// IPとかの設定がないのでとりあえず0番を指定したことにしておく・・・
-				this->servername = configs.at(i).getServerName().at(t);
-				res.addHeader("Server", configs.at(i).getServerName().at(t));
-				return Ok<int>(i);
-			} else if (portflag == true &&
-					   configs.at(i).getServerName().at(t) == without_port) {
-				// std::cout << YELLOW << "in portflag == true" << RESET <<
-				// std::endl;
-				//そのサーバーネームに対してポートが合っているか確認する
-				for (size_t j = 0; j < configs.at(i).getAddresses().size();
-					 j++) {
-					if (configs.at(i).getAddresses().at(j).getPort() ==
-						portnum) {
-						this->addressnum = j;
-						this->confnum = i;
-						this->servername = configs.at(i).getServerName().at(t);
-						res.addHeader("Server",
-									  configs.at(i).getServerName().at(t));
-						return Ok<int>(i);
+
+	// まずIP,ポートを利用してConfigを探す
+	// locationにはIP、ポートは設定できないので検索する必要なし
+	// IP、ポートが一致したものについて、さらにHost名をチェックし、そこまで一致したConfigを選ぶ
+	// 見つからなかった場合はデフォルトサーバーに振り分ける
+	
+	// Configを順番に見ていく
+	for (size_t i = 0; i < configs.size(); i ++)
+	{
+		std::vector<Address> addr;
+		addr = configs.at(i).getAddresses();
+
+		// 一つのConfigの中のアドレスを順番に検索する
+		for (size_t j = 0; j < addr.size(); j ++)
+		{
+			// リクエストが送られてきたサーバーのIPアドレスと、Configでサーバーが設定されているIPアドレスが一致する
+			// IPアドレスが0.0.0.0だった場合はワイルドカード
+			if (req.getLocalAddr() == addr.at(j).getIpAddress() || req.getLocalAddr() == "0.0.0.0" || addr.at(j).getIpAddress() == "0.0.0.0")
+			{
+				// IPアドレスに加え、ポート番号も一致する
+				if (req.getLocalPort() == (unsigned int)addr.at(j).getPort())
+				{
+					// さらにホスト名をチェックする
+					// ワイルドカードは"_"
+					for (size_t k = 0; k < configs.at(i).getServerName().size(); k++)
+					{
+						if (without_port == configs.at(i).getServerName().at(k) || without_port == "_" || configs.at(i).getServerName().at(k) == "_")
+						{
+							addressnum = j;
+							confnum = i;
+							servername = configs.at(i).getServerName().at(k);
+							res.addHeader("Host", servername);
+							return Ok<int>(i);
+						}
 					}
 				}
 			}
@@ -105,7 +119,7 @@ Result<int, bool> RequestHandler::searchMatchHost() {
 	this->confnum = 0;
 	this->addressnum = 0;
 	this->servername = configs.at(confnum).getServerName().at(0);
-	res.addHeader("Server", servername);
+	res.addHeader("Host", servername);
 	return Ok<int>(confnum);
 }
 

--- a/test/src/MethodGet_test.cpp
+++ b/test/src/MethodGet_test.cpp
@@ -6,7 +6,7 @@
 /*   By: komatsud <komatsud@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/25 10:25:25 by komatsud          #+#    #+#             */
-/*   Updated: 2023/10/25 10:40:12 by komatsud         ###   ########.fr       */
+/*   Updated: 2023/10/26 16:56:14 by komatsud         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -171,6 +171,8 @@ TEST(MethodGetTest, getActTest_getDirlistTest) {
 	req.setVersion("HTTP/1.1");
 	req.setMethod("GET");
 	req.addHeader("Host", "kawaii.test");
+	req.setLocalAddr("0.0.0.0");
+	req.setLocalPort(8080);
 	req.setUrl("/www/content/");
 
 	// routing
@@ -206,11 +208,13 @@ TEST(MethodGetTest, getActTest_getIndexTest) {
 	std::string expected_string("OK");
 	bool expected_is_there_content_len(true);
 	std::string expected_hostname("wtf.net");
-	int expected_portnum(80);
+	int expected_portnum(25565);
 
 	req.setVersion("HTTP/1.1");
 	req.setMethod("GET");
 	req.addHeader("Host", expected_hostname);
+	req.setLocalAddr("0.0.0.0");
+	req.setLocalPort(expected_portnum);
 	req.setUrl("/");
 
 	// routing
@@ -251,11 +255,13 @@ TEST(MethodGetTest, getActTest_getIndexTest_FromLocation) {
 	std::string expected_body("What the fuck....");
 	bool expected_is_there_content_len(true);
 	std::string expected_hostname("wtf.net");
-	int expected_portnum(80);
+	int expected_portnum(25565);
 
 	req.setVersion("HTTP/1.1");
 	req.setMethod("GET");
 	req.addHeader("Host", "wtf.net");
+	req.setLocalAddr("0.0.0.0");
+	req.setLocalPort(expected_portnum);
 	req.setUrl("/");
 
 	// routing

--- a/test/src/MethodPost_test.cpp
+++ b/test/src/MethodPost_test.cpp
@@ -6,7 +6,7 @@
 /*   By: komatsud <komatsud@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/25 11:52:26 by komatsud          #+#    #+#             */
-/*   Updated: 2023/10/26 16:57:19 by komatsud         ###   ########.fr       */
+/*   Updated: 2023/10/26 17:16:22 by komatsud         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -60,6 +60,8 @@ TEST(MethodPostTest, postTextFileTest) {
 	req.setMethod("POST");
 	req.addHeader("Host", "_");
 	req.setBody(expected_content);
+	req.setLocalAddr("111.108.92.125:8660");
+	req.setLocalPort(8660);
 	req.addHeader("Content-Length", "11");
 	req.setUrl("/post");
 

--- a/test/src/MethodPost_test.cpp
+++ b/test/src/MethodPost_test.cpp
@@ -6,7 +6,7 @@
 /*   By: komatsud <komatsud@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/25 11:52:26 by komatsud          #+#    #+#             */
-/*   Updated: 2023/10/23 15:00:57 by komatsud         ###   ########.fr       */
+/*   Updated: 2023/10/26 16:57:19 by komatsud         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -103,6 +103,8 @@ TEST(MethodPostTest, postTextFileTest_Error_methodNotAllowed) {
 	req.setBody(expected_content);
 	req.addHeader("Content-Length", "40");
 	req.setUrl("/post");
+	req.setLocalAddr("0.0.0.0");
+	req.setLocalPort(25565);
 
 	RequestHandler handler = RequestHandler(tmp, req);
 	handler.searchMatchHost();

--- a/test/src/RequestHandler_test.cpp
+++ b/test/src/RequestHandler_test.cpp
@@ -6,7 +6,7 @@
 /*   By: komatsud <komatsud@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/20 18:17:48 by komatsud          #+#    #+#             */
-/*   Updated: 2023/10/26 17:08:25 by komatsud         ###   ########.fr       */
+/*   Updated: 2023/10/26 17:17:02 by komatsud         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -41,7 +41,7 @@ TEST(RequestHandlerTest, searchMatchHostTest) {
 	req.setLocalAddr("0.0.0.0");
 	req.setLocalPort(8080);
 
-	std::clog << RED << "Segmentation fault" << RESET << std::endl;
+	//std::clog << RED << "Segmentation fault" << RESET << std::endl;
 	RequestHandler handler = RequestHandler(tmp, req);
 	Result<int, bool> result_1 = handler.searchMatchHost();
 	ASSERT_EQ(result_1.getOk(), expected);
@@ -436,6 +436,8 @@ TEST(RequestHandlerTest, getHostnameTest) {
 	req.setMethod("GET");
 	req.addHeader("Host", "_");
 	req.setUrl("/dummy/test");
+	req.setLocalPort(expected_port);
+	req.setLocalAddr(expected_host);
 
 	RequestHandler handler = RequestHandler(tmp, req);
 	handler.searchMatchHost();

--- a/test/src/RequestHandler_test.cpp
+++ b/test/src/RequestHandler_test.cpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   RequestHandler_test.cpp                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: shtanemu <shtanemu@student.42.fr>          +#+  +:+       +#+        */
+/*   By: komatsud <komatsud@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/20 18:17:48 by komatsud          #+#    #+#             */
-/*   Updated: 2023/10/26 11:34:38 by shtanemu         ###   ########.fr       */
+/*   Updated: 2023/10/26 16:49:21 by komatsud         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,6 +26,7 @@
 #define CONF_FILE_PATH "testconfs/simple.conf"
 #define CONF_FILE_WITH_ONE_LOC "testconfs/location_dir.conf"
 #define CONF_FOR_ALIAS_TEST "testconfs/alias_test.conf"
+#define CONF_FOR_ROUTING_TEST "testconfs/routingtest.conf"
 
 TEST(RequestHandlerTest, searchMatchHostTest) {
 	std::vector<Config> tmp;
@@ -37,8 +38,10 @@ TEST(RequestHandlerTest, searchMatchHostTest) {
 	req.setVersion("HTTP/1.1");
 	req.setMethod("GET");
 	req.addHeader("Host", "kawaii.test");
+	req.setLocalAddr("0.0.0.0");
+	req.setLocalPort(8080);
 
-	std::clog << RED << "Segmentatio fault" << RESET << std::endl;
+	std::clog << RED << "Segmentation fault" << RESET << std::endl;
 	RequestHandler handler = RequestHandler(tmp, req);
 	Result<int, bool> result_1 = handler.searchMatchHost();
 	ASSERT_EQ(result_1.getOk(), expected);
@@ -331,6 +334,8 @@ TEST(RequestHandlerTest, getCgiInfoTest) {
 	req.setVersion("HTTP/1.1");
 	req.setMethod("GET");
 	req.addHeader("Host", "cgi.test");
+	req.setLocalPort(8080);
+	req.setLocalAddr("0.0.0.0");
 	req.setUrl(expected_path);
 
 	RequestHandler handler = RequestHandler(tmp, req);
@@ -339,7 +344,7 @@ TEST(RequestHandlerTest, getCgiInfoTest) {
 	handler.routeMethod();
 	handler.isCgi();
 
-	// std::cout << handler.getResponse().getLines() << std::endl;
+	//std::cout << handler.getResponse().getLines() << std::endl;
 
 	ASSERT_EQ(handler.isCgi().isOK(), expected_status);
 	ASSERT_EQ(handler.isCgi().getOk(), "." + expected_path);
@@ -357,6 +362,8 @@ TEST(RequestHandlerTest, Error_ENOENT_getCgiInfoTest) {
 	req.setVersion("HTTP/1.1");
 	req.setMethod("GET");
 	req.addHeader("Host", "cgi.test");
+	req.setLocalPort(8080);
+	req.setLocalAddr("0.0.0.0");
 	req.setUrl(expected_path);
 
 	RequestHandler handler = RequestHandler(tmp, req);
@@ -387,6 +394,8 @@ TEST(RequestHandlerTest, Error_EACCES_getCgiInfoTest) {
 	req.setVersion("HTTP/1.1");
 	req.setMethod("GET");
 	req.addHeader("Host", "cgi.test");
+	req.setLocalPort(8080);
+	req.setLocalAddr("0.0.0.0");
 	req.setUrl(expected_path);
 
 	RequestHandler handler = RequestHandler(tmp, req);
@@ -459,3 +468,32 @@ TEST(RequestHandlerTest, setAliasTest) {
 	ASSERT_EQ(handler.getResponse().getHeader("Content-Length").isOK(),
 			  expected_is_there_content_len);
 }
+
+TEST(RequestHandlerTest, routingTest_1) {
+	Result<std::vector<Config>, bool> res = parseConf(CONF_FOR_ROUTING_TEST);
+	std::vector<Config> tmp = res.getOk();
+	Request req;
+	std::string expected_host("lastserver");
+	int expected_port(4040);
+	bool expected_is_there_content_len(true);
+	bool iscgi(false);
+
+	req.setVersion("HTTP/1.1");
+	req.setMethod("GET");
+	req.addHeader("Host", expected_host);
+	req.setUrl("/test/conf/wtf.txt");
+	req.setLocalAddr("1.1.1.1");
+	req.setLocalPort(expected_port);
+
+	RequestHandler handler = RequestHandler(tmp, req);
+	handler.searchMatchHost();
+	handler.checkRequiedHeader();
+	handler.routeMethod();
+
+	ASSERT_EQ(handler.isCgi().isOK(), iscgi);
+	ASSERT_EQ(handler.getHostname(), expected_host);
+	ASSERT_EQ(handler.getPortNumber(), expected_port);
+	ASSERT_EQ(handler.getResponse().getHeader("Host").getOk(), expected_host);
+	ASSERT_EQ(handler.getResponse().getHeader("Content-Length").isOK(), expected_is_there_content_len);
+}
+

--- a/test/src/RequestHandler_test.cpp
+++ b/test/src/RequestHandler_test.cpp
@@ -6,7 +6,7 @@
 /*   By: komatsud <komatsud@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/20 18:17:48 by komatsud          #+#    #+#             */
-/*   Updated: 2023/10/26 16:49:21 by komatsud         ###   ########.fr       */
+/*   Updated: 2023/10/26 17:08:25 by komatsud         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -57,6 +57,8 @@ TEST(RequestHandlerTest, searchMatchHostTest_withPort) {
 	req.setVersion("HTTP/1.1");
 	req.setMethod("GET");
 	req.addHeader("Host", "kawaii.test:80");
+	req.setLocalAddr("0.0.0.0");
+	req.setLocalPort(80);
 
 	RequestHandler handler = RequestHandler(tmp, req);
 	Result<int, bool> result_1 = handler.searchMatchHost();
@@ -73,6 +75,8 @@ TEST(RequestHandlerTest, searchMatchHostTest_withPort_2) {
 	req.setVersion("HTTP/1.1");
 	req.setMethod("GET");
 	req.addHeader("Host", "_:8660");
+	req.setLocalAddr("0.0.0.0");
+	req.setLocalPort(8660);
 
 	RequestHandler handler = RequestHandler(tmp, req);
 	Result<int, bool> result_1 = handler.searchMatchHost();
@@ -91,6 +95,8 @@ TEST(RequestHandlerTest, searchMatchHostTest_Error_withWrongPort) {
 	req.setVersion("HTTP/1.1");
 	req.setMethod("GET");
 	req.addHeader("Host", "kawaii.test:28282");
+	req.setLocalAddr("0.0.0.0");
+	req.setLocalPort(28282);
 
 	RequestHandler handler = RequestHandler(tmp, req);
 	Result<int, bool> result_1 = handler.searchMatchHost();
@@ -116,6 +122,8 @@ TEST(RequestHandlerTest, searchMatchHostTest_Error_withWrongPort_2) {
 	req.setMethod("GET");
 	req.addHeader("Host", "www.kawaii.test:9999");
 	req.setUrl("/");
+	req.setLocalAddr("0.0.0.0");
+	req.setLocalPort(9999);
 
 	RequestHandler handler = RequestHandler(tmp, req);
 	Result<int, bool> result_1 = handler.searchMatchHost();
@@ -140,6 +148,8 @@ TEST(RequestHandlerTest, searchMatchHostTest_Error_withWrongPort_3) {
 	req.setVersion("HTTP/1.1");
 	req.setMethod("GET");
 	req.addHeader("Host", "_:9999");
+	req.setLocalAddr("0.0.0.0");
+	req.setLocalPort(9999);
 
 	RequestHandler handler = RequestHandler(tmp, req);
 	Result<int, bool> result_1 = handler.searchMatchHost();

--- a/test/testconfs/location_dir.conf
+++ b/test/testconfs/location_dir.conf
@@ -62,6 +62,7 @@ server {
 }
 
 server {
+		listen	25565;
 		server_name	wtf.net;
 		root /www/content;
 

--- a/test/testconfs/method_get.conf
+++ b/test/testconfs/method_get.conf
@@ -39,6 +39,7 @@ server {
 }
 
 server {
+		listen	25565;
         server_name  wtf.net;
 		root		/www/content;
  

--- a/test/testconfs/method_post.conf
+++ b/test/testconfs/method_post.conf
@@ -37,8 +37,7 @@ server {
 }
 
 server {
-		listen		8080;
-		listen		80;
+		listen		25565;
 		server_name	met_not_allowed.com;
 		root		/content;
 		#rewrite		/content/ok.html yahoo.co.jp;

--- a/test/testconfs/routingtest.conf
+++ b/test/testconfs/routingtest.conf
@@ -1,35 +1,30 @@
 
 server {
-        listen       111.108.92.125:8660;
-        listen       [::]:80;
-        server_name  _;
-        root         /usr/share/nginx/html;
+		listen 		25565;
+        server_name  defaultserver;
+		root		 /content;
  
         # Load configuration files for the default server block.
-        # include /etc/nginx/default.d/*.conf
+        # include /etc/nginx/default.d/*.conf;
  
-		rewrite test/test/what.html google.com;
-		return 440;
 		client_max_body_size 5m;
 		upload_path	/content;
 
-        error_page 404 /404.html;
-        error_page 500 /500.html;
-		error_page 505 error_pages/505.html;
+        # error_page 404 /404.html;
+        # error_page 500 /500.html;
+		# error_page 505 error_pages/505.html;
 
-		autoindex off;
-		index index.html;
+		index readme.html;
+		autoindex on;
 		allowedMethods	GET POST DELETE;
-		cgi_extension py cgi;
 }
 
 server {
-		listen		8080;
-		listen		80;
-		server_name	kawaii.test www.kawaii.test;
-		root		/content;
+		listen 2.2.2.2:8080;
+		server_name	kawaii.test;
+		root		/www/content;
 		rewrite		/content/ok.html yahoo.co.jp;
-		return		301 https://www.google.co.jp/;
+		return		202 https://www.google.co.jp/;
 
 		autoindex on;
 		client_max_body_size 10k;
@@ -42,18 +37,20 @@ server {
 }
 
 server {
-		server_name	cgi.test;
-		listen 8080;
-		root		/;
+        listen 1.1.1.1:4040;
+		server_name	lastserver;
+		root		/www/content;
+		rewrite		/content/ok.html yahoo.co.jp;
+		return		202 https://www.google.co.jp/;
 
 		autoindex on;
 		client_max_body_size 10k;
-		upload_path /post;
+		upload_path Users/komatsud/webserv/html/www/content/;
 
 		error_page 400 /error_pages/400.html;
 		error_page 501 /error_pages/501.html;
 		index index.php index.test;
-		cgi_extension py cgi;
 		allowedMethods	GET POST;
 }
+
 


### PR DESCRIPTION
新しいルーティング方式
・まずIPの一致を見る
・IPが一致していたらポートを確認する
・ポートが一致していたらホスト名が一致しているか確認する
・全て合っていたらそのサーバーに振り分ける
・全て合っているものが見つからなかったらデフォルトサーバーに振り分ける
・ホスト名のワイルドカードは_、IPのワイルドカードは0.0.0.0です